### PR TITLE
Make IDs required. Without this, does a query with an empty where clause

### DIFF
--- a/app/api/bigquery/parsers.py
+++ b/app/api/bigquery/parsers.py
@@ -12,11 +12,11 @@ pagination_arguments.add_argument('per_page', type=int, required=False, choices=
 
 
 query_url_parser = reqparse.RequestParser()
-query_url_parser.add_argument('ids1', help="""A comma delimited list of Entrez gene ids to select.\n
+query_url_parser.add_argument('ids1', required=True, help="""A comma delimited list of Entrez gene ids to select.\n
 **Default**: all genes.\n
 **Example**:"5111,6996,57697,6815,889,7112,2176,1019,5888,5706"
 """)
-query_url_parser.add_argument( 'ids2', help="""Entrez gene ids to select.
+query_url_parser.add_argument( 'ids2', required=True, help="""Entrez gene ids to select.
 If not given, the query selects any gene related to a gene in ids 1.
 If given, the query only selects relations that contain a gene in ids1 and a gene in ids2.\n
 **Default**: all genes.\n

--- a/app/test/features/steps/step_bigclam_interactions.py
+++ b/app/test/features/steps/step_bigclam_interactions.py
@@ -16,11 +16,18 @@ def invalid_run_bigclam_g2g_query(context):
   json_response = run_bigclam_g2g_query(invalid_request)
   context.json_response = json_response
 
-@given('a valid run_bigclam_g2g_query')
+@when('I run a valid run_bigclam_g2g_query')
 def valid_run_bigclam_g2g_query(context):
   valid_request = {'ids': 'TCOF1'}
-  json_response = run_bigclam_g2g_query(valid_request)
-  context.json_response = json_response
+  googleinterface = context.googleinterface
+  print(googleinterface.query.return_value)
+  with patch('app.api.bigquery.bigclam_interactions.GoogleInterface') as mock_googleinterface:
+    mock_googleinterface().query.return_value = googleinterface.query.return_value
+
+    json_response = run_bigclam_g2g_query(valid_request)
+    print("json_response in valid_run_bigclam_g2g_query", json_response)
+    context.json_response = json_response
+    assert 1 == 0
 
 @given('a bigclam run_bigclam_g2d_query with invalid request')
 def invalid_run_bigclam_g2d_query(context):
@@ -32,8 +39,14 @@ def invalid_run_bigclam_g2d_query(context):
   json_response = run_bigclam_g2d_query(invalid_request)
   context.json_response = json_response
 
-@given('a valid run_bigclam_g2d_query')
+@when('I run a valid run_bigclam_g2d_query')
 def valid_run_bigclam_g2d_query(context):
   valid_request = {'ids': 'TCOF1'}
-  json_response = run_bigclam_g2d_query(valid_request)
-  context.json_response = json_response
+  googleinterface = context.googleinterface
+  print(googleinterface.query.return_value)
+  with patch('app.api.bigquery.bigclam_interactions.GoogleInterface') as mock_googleinterface:
+    mock_googleinterface().query.return_value = googleinterface.query.return_value
+
+    json_response = run_bigclam_g2d_query(valid_request)
+    print("json_response in valid_run_bigclam_g2d_query", json_response)
+    context.json_response = json_response

--- a/app/test/features/steps/step_googleinterface.py
+++ b/app/test/features/steps/step_googleinterface.py
@@ -1,3 +1,4 @@
+import uuid
 from behave import given, when, then
 from mock import Mock, patch
 from google.cloud.bigquery.query import QueryResults
@@ -269,3 +270,16 @@ def successful_storage_results(context):
     u'kind': u'storage#objects'
   }
   context.bucket = mock_bucket
+
+@given('I receive a successful query job submission')
+def successful_query_submission_results(context):
+  """ For bigclam_interactions.py:run_bigclam_g2g_query/run_bigclam_g2d_query """
+  """ Needs to patch GoogleInterface.query to return a UUID4 """
+  if 'googleinterface' in context:
+    print("FOUND successful_query_submission_results MOCK")
+    googleinterface = context.googleinterface
+  else:
+    googleinterface = Mock()
+
+  googleinterface.query.return_value = str(uuid.uuid4())
+  context.googleinterface = googleinterface

--- a/app/test/features/translator_bigclam_bi.feature
+++ b/app/test/features/translator_bigclam_bi.feature
@@ -1,13 +1,14 @@
 # Tests bigclam_interactions.py
 
-Feature:
+Feature: BigCLAM Business
 
     Scenario: User runs an invalid run_bigclam_g2g_query
         Given a bigclam run_bigclam_g2g_query with invalid request
         Then a json error message is returned
 
     Scenario: User submits a valid run_bigclam_g2g_query
-        Given a valid run_bigclam_g2g_query
+        Given I receive a successful query job submission
+        When I run a valid run_bigclam_g2g_query
         Then no json error messages are returned
 
     Scenario: User runs an invalid run_bigclam_g2d_query
@@ -15,6 +16,7 @@ Feature:
         Then a json error message is returned
 
     Scenario: User submits a valid run_bigclam_g2d_query
-        Given a valid run_bigclam_g2d_query
+        Given I receive a successful query job submission
+        When I run a valid run_bigclam_g2d_query
         Then no json error messages are returned
 


### PR DESCRIPTION
Without both ids1 and ids2, this submits a query to BigQuery that has an empty where clause.


SELECT * 
FROM `isb-cgc-04-0010.NTTB_BigGIM.BigGIM_70_v1`
WHERE ((Gene1 IN () AND Gene2 IN (57697,6815,889,7112,2176,1019,5888)) OR (Gene1 IN (57697,6815,889,7112,2176,1019,5888) AND Gene2 IN ()))
LIMIT 10


Is the appropriate fix to require the ids or is it to fix the where query?